### PR TITLE
Stem query words in wordMatch

### DIFF
--- a/ProductSearchRelevance.FSharp/ProductSearchRelevance/ProductSearchRelevance.FSharp.fsproj
+++ b/ProductSearchRelevance.FSharp/ProductSearchRelevance/ProductSearchRelevance.FSharp.fsproj
@@ -137,5 +137,16 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.1'">
+      <ItemGroup>
+        <Reference Include="StemmersNet">
+          <HintPath>..\packages\StemmersNet\lib\net20\StemmersNet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Import Project="..\packages\Accord\build\$(__paket__Accord_targets).targets" Condition="Exists('..\packages\Accord\build\$(__paket__Accord_targets).targets')" Label="Paket" />
 </Project>

--- a/ProductSearchRelevance.FSharp/ProductSearchRelevance/paket.references
+++ b/ProductSearchRelevance.FSharp/ProductSearchRelevance/paket.references
@@ -3,3 +3,4 @@ Accord.Math
 Accord.Statistics
 FSharp.Collections.ParallelSeq
 FSharp.Data
+StemmersNet

--- a/ProductSearchRelevance.FSharp/paket.dependencies
+++ b/ProductSearchRelevance.FSharp/paket.dependencies
@@ -6,3 +6,4 @@ nuget Accord.Math >= 3.0.2
 nuget Accord.Statistics >= 3.0.2
 nuget FSharp.Collections.ParallelSeq >= 1.0.2
 nuget FSharp.Data >= 2.2.5
+nuget StemmersNet

--- a/ProductSearchRelevance.FSharp/paket.lock
+++ b/ProductSearchRelevance.FSharp/paket.lock
@@ -10,3 +10,4 @@ NUGET
       Accord.Math (>= 3.0.2)
     FSharp.Collections.ParallelSeq (1.0.2)
     FSharp.Data (2.2.5)
+    StemmersNet (1.1.1)


### PR DESCRIPTION
This allows some degree of fuzzy matching between query terms and titles/descriptions. I spot checked some new matches and didn't see false positives, so hopefully it improves the score. I suppose also stemming the title/description words is an option too.
