### PR TITLE
Fix train/test data ordering

### DIFF
--- a/ProductSearchRelevance.FSharp/ProductSearchRelevance/benchmarkScore.fsx
+++ b/ProductSearchRelevance.FSharp/ProductSearchRelevance/benchmarkScore.fsx
@@ -9,7 +9,6 @@ open System
 open System.IO
 open System.Text.RegularExpressions
 open FSharp.Data
-open FSharp.Collections.ParallelSeq
 open Accord.Statistics.Models.Regression.Linear
 open Iveonik.Stemmers
 
@@ -53,8 +52,8 @@ let inline toFloatArray (a,b,c) = [| float a; float b; float c |]
 
 let trainInput = 
     train.Rows
-    |> PSeq.map (fun w -> wordMatch w.Search_term w.Product_title (productDescription w.Product_uid) |> toFloatArray)
-    |> PSeq.toArray
+    |> Seq.map (fun w -> wordMatch w.Search_term w.Product_title (productDescription w.Product_uid) |> toFloatArray)
+    |> Seq.toArray
 
 let trainOutput = 
     train.Rows
@@ -63,8 +62,8 @@ let trainOutput =
 
 let testInput = 
     test.Rows 
-    |> PSeq.map (fun w -> wordMatch w.Search_term w.Product_title (productDescription w.Product_uid) |> toFloatArray)
-    |> PSeq.toArray
+    |> Seq.map (fun w -> wordMatch w.Search_term w.Product_title (productDescription w.Product_uid) |> toFloatArray)
+    |> Seq.toArray
 
 let target = MultipleLinearRegression(3, true)
 let error = target.Regress(trainInput, trainOutput)


### PR DESCRIPTION
`PSeq.map` doesn't preserve the order of the input sequence, so the output was "scrambled". I noticed this after using `PSeq.map` to parallelize the output CSV; the IDs were unsorted. I think this might've significantly affected the score.
